### PR TITLE
Adds upgrade support for ACLs from 4.7.5 to 5.x

### DIFF
--- a/src/main/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManager.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManager.java
@@ -17,16 +17,26 @@
  */
 package org.fcrepo.upgrade.utils;
 
+import static java.net.URI.create;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.fcrepo.upgrade.utils.HttpConstants.CONTENT_LOCATION_HEADER;
 import static org.fcrepo.upgrade.utils.HttpConstants.CONTENT_TYPE_HEADER;
 import static org.fcrepo.upgrade.utils.HttpConstants.LINK_HEADER;
 import static org.fcrepo.upgrade.utils.HttpConstants.LOCATION_HEADER;
+import static org.fcrepo.upgrade.utils.RdfConstants.ACCESS_CONTROL;
+import static org.fcrepo.upgrade.utils.RdfConstants.ACL;
+import static org.fcrepo.upgrade.utils.RdfConstants.ACL_NS;
+import static org.fcrepo.upgrade.utils.RdfConstants.AUTHORIZATION;
 import static org.fcrepo.upgrade.utils.RdfConstants.EBUCORE_HAS_MIME_TYPE;
+import static org.fcrepo.upgrade.utils.RdfConstants.FEDORA_CREATED_BY;
 import static org.fcrepo.upgrade.utils.RdfConstants.FEDORA_CREATED_DATE;
+import static org.fcrepo.upgrade.utils.RdfConstants.FEDORA_LAST_MODIFIED_BY;
+import static org.fcrepo.upgrade.utils.RdfConstants.FEDORA_LAST_MODIFIED_DATE;
 import static org.fcrepo.upgrade.utils.RdfConstants.FEDORA_VERSION;
 import static org.fcrepo.upgrade.utils.RdfConstants.LDP_BASIC_CONTAINER;
 import static org.fcrepo.upgrade.utils.RdfConstants.LDP_CONTAINER;
 import static org.fcrepo.upgrade.utils.RdfConstants.LDP_CONTAINER_TYPES;
+import static org.fcrepo.upgrade.utils.RdfConstants.LDP_CONTAINS;
 import static org.fcrepo.upgrade.utils.RdfConstants.LDP_NON_RDF_SOURCE;
 import static org.fcrepo.upgrade.utils.RdfConstants.LDP_RDF_SOURCE;
 import static org.fcrepo.upgrade.utils.RdfConstants.MEMENTO;
@@ -44,11 +54,14 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -59,9 +72,9 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.vocabulary.RDF;
@@ -84,11 +97,11 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
     private static final String MEMENTO_DATETIME_HEADER = "Memento-Datetime";
     private static final String FCR_METADATA_PATH_SEGMENT = "fcr%3Ametadata";
     private static final String FCR_VERSIONS_PATH_SEGMENT = "fcr%3Aversions";
+    public static final String FCR_ACL_PATH_SEGMENT = "fcr%3Aacl";
     private static final String TYPE_RELATION = "type";
     private static final String TURTLE_EXTENSION = ".ttl";
     private static final String HEADERS_SUFFIX = ".headers";
     public static final String APPLICATION_OCTET_STREAM_MIMETYPE = "application/octet-stream";
-
     /**
      * Constructor
      *
@@ -122,7 +135,6 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
         }
 
         final boolean isVersionedResource = path.toString().contains(FCR_VERSIONS_PATH_SEGMENT + File.separator);
-        final boolean isBinaryDescription = path.toString().contains(FCR_METADATA_PATH_SEGMENT);
         final Path inputPath = this.config.getInputDir().toPath();
         final Path relativePath = inputPath.relativize(path);
         final Path relativeNewLocation;
@@ -175,8 +187,14 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
         final var rdfTypes = statements.stream().filter(s -> s.getPredicate().equals(RDF.type))
                                        .map(s -> s.getObject().asResource()).collect(Collectors.toList());
         final var isBinary = rdfTypes.contains(LDP_NON_RDF_SOURCE);
-
         final var isContainer = rdfTypes.contains(LDP_CONTAINER);
+
+        //skip if ACL or Authorization: these files are upgraded through a separate code path
+        // see convertAcl() below.
+        if (rdfTypes.contains(ACL) || rdfTypes.contains(AUTHORIZATION)) {
+            newLocation.toFile().delete();
+            return;
+        }
 
         rdfTypes.retainAll(LDP_CONTAINER_TYPES);
         final var isConcreteContainerDefined = !rdfTypes.isEmpty();
@@ -242,6 +260,17 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
                     }
                 }
                 binaryHeaders.put(CONTENT_TYPE_HEADER, Collections.singletonList(mimetype));
+            } else if (statement.getPredicate().equals(ACCESS_CONTROL)) {
+                //remove the current statement across both past versions and latest version
+                model.remove(currentStatement);
+                rewriteModel.set(true);
+
+                //on the latest version
+                if(versionTimestamp == null) {
+                    //convert the acl
+                    convertAcl(newLocation, currentStatement.getSubject().getURI(),
+                               currentStatement.getObject().asResource().getURI());
+                }
             }
         });
 
@@ -297,6 +326,78 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
         LOGGER.debug("containerSubject={}", containerSubject);
     }
 
+    private void convertAcl(final Path convertedProtectedResourceLocation, String protectedResource, String aclUri) {
+        //locate the exported acl rdf on disk based on aclURI
+        final var relativeAclPath = create(aclUri).getPath();
+        final var aclDirectory = Path.of(this.config.getInputDir().toPath().toString(), relativeAclPath.toString());
+        final var aclRdfFilePath = aclDirectory.toString() + TURTLE_EXTENSION;
+        final var newAclResource = ResourceFactory.createResource(protectedResource + "/fcr:acl");
+        final var aclModel = createModelFromFile(Path.of(aclRdfFilePath));
+        final var aclTriples = new ArrayList<Statement>();
+        final var allowablePredicates = Arrays.asList(RDF.type, FEDORA_CREATED_DATE, FEDORA_LAST_MODIFIED_DATE, FEDORA_CREATED_BY, FEDORA_LAST_MODIFIED_BY);
+        aclModel.listStatements().toList().stream().filter(x->allowablePredicates.contains(x.getPredicate()))
+                .forEach(x -> {
+            final var obj = x.getObject();
+            final var predicate = x.getPredicate();
+            if ( !(predicate.equals(RDF.type) && obj.isResource() && obj.equals(ACL))) {
+                aclTriples.add(aclModel.createStatement(newAclResource, x.getPredicate(), x.getObject()));
+            }
+        });
+
+        final var newAclFilePath = Path
+            .of(removeExtension(convertedProtectedResourceLocation.toString()),
+                FCR_ACL_PATH_SEGMENT + TURTLE_EXTENSION);
+
+        //determine the location of new acl
+        final var authorizations = new LinkedHashMap<String, List<Statement>>();
+        var authIndex = new AtomicInteger(0);
+        try (final Stream<Path> list = Files.walk(aclDirectory)) {
+            list.filter(Files::isRegularFile).forEach(authFile -> {
+                 final var model = createModelFromFile(authFile);
+                final var authName = "auth" + authIndex.get();
+                final var subject = createResource(newAclResource + "#" + authName);
+                final var isAuthorization = new AtomicBoolean(false);
+                final var authTriples = new ArrayList<Statement>();
+                model.listStatements().toList().stream().filter(x-> {
+                    //filter only rdf type Authorization and acl namespace  predicates
+                    return (x.getPredicate().equals(RDF.type) && x.getObject().asResource().equals(AUTHORIZATION)) ||
+                           x.getPredicate().toString().startsWith(ACL_NS);
+                }).forEach(x->{
+                    var object = x.getObject();
+                    if (x.getPredicate().equals(RDF.type) && x.getObject().asResource().equals(AUTHORIZATION)) {
+                        isAuthorization.set(true);
+                    }
+                    authTriples.add(model.createStatement(subject, x.getPredicate(), object));
+                });
+
+                authIndex.incrementAndGet();
+                if (isAuthorization.get()) {
+                    authorizations.put(authName, authTriples);
+                }
+            });
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        //create new model
+        final var newModel = ModelFactory.createDefaultModel();
+        //add acl level triples
+        aclTriples.forEach(x -> newModel.add(x));
+        //add all authorizations to a single model
+        for (String key : authorizations.keySet()) {
+            authorizations.get(key).forEach(x -> {
+                newModel.add(x);
+            });
+        }
+
+        //save to new acl to file
+        try (final FileOutputStream os = new FileOutputStream(newAclFilePath.toFile())) {
+            RDFDataMgr.write(os, newModel, Lang.TTL);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private String locateBinaryHeadersPrefixForVersionedBinary(final Path newLocation) {
         //the idea here is translate a versioned metadata resource
         //   from
@@ -310,7 +411,7 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
     }
 
     private Resource getOriginalResource(Resource resource) {
-        return ResourceFactory.createResource(resource.getURI()
+        return createResource(resource.getURI()
                                                       .replaceAll("/fcr:versions/[a-zA-Z0-9.]*", ""));
     }
 
@@ -340,35 +441,37 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
         var metadataPath = path;
         if (!path.toString().endsWith(TURTLE_EXTENSION)) {
             final var metadataPathStr = metadataPath.toString();
-            final var index = metadataPathStr.lastIndexOf(".");
-            final var newMetadataPathStr = metadataPathStr
-                                               .substring(0,
-                                                          index) + File.separator + FCR_METADATA_PATH_SEGMENT + TURTLE_EXTENSION;
+            final var newMetadataPathStr = removeExtension(metadataPathStr) + File.separator + FCR_METADATA_PATH_SEGMENT + TURTLE_EXTENSION;
             metadataPath = Path.of(newMetadataPathStr);
         }
 
         //resolve the subject associated with the resource
-        final Model model = ModelFactory.createDefaultModel();
-        try (final FileInputStream is = new FileInputStream(metadataPath.toFile())) {
-            RDFDataMgr.read(model, is, Lang.TTL);
-        } catch (IOException ex) {
-            throw new RuntimeException(ex);
-        }
+        final Model model = createModelFromFile(metadataPath);
         final var subject = model.listSubjects().nextResource();
 
         //resolve the versions file
         final var versionsContainer = resolveVersionsContainer(path);
         //read the versions container in order to resolve the version timestamp
-        final Model versionsContainerModel = ModelFactory.createDefaultModel();
-        try (final FileInputStream is = new FileInputStream(versionsContainer.toFile())) {
-            RDFDataMgr.read(versionsContainerModel, is, Lang.TTL);
-        } catch (IOException ex) {
-            throw new RuntimeException(ex);
-        }
+        final Model versionsContainerModel = createModelFromFile(versionsContainer);
         final var iso8601Timestamp = versionsContainerModel.listObjectsOfProperty(subject, FEDORA_CREATED_DATE)
                                                            .next().asLiteral().getString();
         //create memento id based on RFC 8601 timestamp
         return ISO_DATE_TIME_FORMATTER.parse(iso8601Timestamp);
+    }
+
+    private String removeExtension(String path) {
+        final var index = path.lastIndexOf(".");
+        return path.substring(0, index);
+    }
+
+    private Model createModelFromFile(final Path path) {
+        final Model model = ModelFactory.createDefaultModel();
+        try (final FileInputStream is = new FileInputStream(path.toFile())) {
+            RDFDataMgr.read(model, is, Lang.TTL);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+        return model;
     }
 
     private Path resolveNewVersionedResourceLocation(final Path path, final TemporalAccessor mementoTimestamp) {

--- a/src/main/java/org/fcrepo/upgrade/utils/RdfConstants.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/RdfConstants.java
@@ -41,10 +41,14 @@ public class RdfConstants {
     }
 
     public static final String FEDORA_NS = "http://fedora.info/definitions/v4/repository#";
+    public static final String ACL_NS = "http://www.w3.org/ns/auth/acl#";
     public static final String LDP_NS = "http://www.w3.org/ns/ldp#";
     public static final String MEMENTO_NS = "http://mementoweb.org/ns#";
     public static final String PREMIS_NS = "http://www.loc.gov/premis/rdf/v1#";
     public static final String EBUCORE_NS = "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#";
+
+    public static final Resource ACL = ResourceFactory.createResource( "http://fedora.info/definitions/v4/webac#Acl");
+    public static final Resource AUTHORIZATION = ResourceFactory.createResource(ACL_NS + "Authorization");
 
     public static final Resource LDP_NON_RDF_SOURCE = ResourceFactory.createResource(LDP_NS + "NonRDFSource");
     public static final Resource LDP_RDF_SOURCE = ResourceFactory.createResource(LDP_NS + "RDFSource");
@@ -58,7 +62,7 @@ public class RdfConstants {
     public static final List<Resource> LDP_CONTAINER_TYPES = Arrays.asList(LDP_BASIC_CONTAINER,
                                                                            LDP_DIRECT_CONTAINER,
                                                                            LDP_INDIRECT_CONTAINER);
-
+    public static final Resource LDP_CONTAINS = ResourceFactory.createResource(LDP_NS + "contains");
     public static final Resource FEDORA_VERSION = ResourceFactory.createResource(FEDORA_NS + "Version");
     public static final Resource MEMENTO = ResourceFactory.createResource(MEMENTO_NS + "Memento");
 
@@ -75,6 +79,11 @@ public class RdfConstants {
             createProperty(FEDORA_NS + "createdBy");
     public static final Property FEDORA_CREATED_DATE =
             createProperty(FEDORA_NS + "created");
+
+    public static final Property FEDORA_WEB_ACL =
+        createProperty( "http://fedora.info/definitions/v4/webac#Acl");
+
+    public static final Property ACCESS_CONTROL = createProperty(ACL_NS + "accessControl");
 
     public static final Property HAS_FIXITY_RESULT =
             createProperty(PREMIS_NS + "hasFixity");

--- a/src/main/java/org/fcrepo/upgrade/utils/RdfConstants.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/RdfConstants.java
@@ -62,7 +62,6 @@ public class RdfConstants {
     public static final List<Resource> LDP_CONTAINER_TYPES = Arrays.asList(LDP_BASIC_CONTAINER,
                                                                            LDP_DIRECT_CONTAINER,
                                                                            LDP_INDIRECT_CONTAINER);
-    public static final Resource LDP_CONTAINS = ResourceFactory.createResource(LDP_NS + "contains");
     public static final Resource FEDORA_VERSION = ResourceFactory.createResource(FEDORA_NS + "Version");
     public static final Resource MEMENTO = ResourceFactory.createResource(MEMENTO_NS + "Memento");
 
@@ -79,9 +78,6 @@ public class RdfConstants {
             createProperty(FEDORA_NS + "createdBy");
     public static final Property FEDORA_CREATED_DATE =
             createProperty(FEDORA_NS + "created");
-
-    public static final Property FEDORA_WEB_ACL =
-        createProperty( "http://fedora.info/definitions/v4/webac#Acl");
 
     public static final Property ACCESS_CONTROL = createProperty(ACL_NS + "accessControl");
 

--- a/src/test/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManagerTest.java
+++ b/src/test/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManagerTest.java
@@ -164,10 +164,12 @@ public class F47ToF5UpgradeManagerTest {
                    authSubjects.contains("http://localhost:8080/rest/container1/fcr:acl#auth1"));
 
         final var lastModifiedStatement = model.listStatements().toList().stream()
-                                               .filter(x -> x.getPredicate().equals(FEDORA_LAST_MODIFIED_DATE)).findFirst().get();
+                                               .filter(x -> x.getPredicate().equals(FEDORA_LAST_MODIFIED_DATE))
+                                               .findFirst().get();
         assertTrue("There should be a last modified date", lastModifiedStatement != null);
         assertEquals("The subject should be be the acl: ",
-                     "http://localhost:8080/rest/container1/fcr:acl", lastModifiedStatement.getSubject().getURI());
+                     "http://localhost:8080/rest/container1/fcr:acl",
+                     lastModifiedStatement.getSubject().getURI());
     }
 
     private Map<String, List<String>> deserializeHeaders(final File headerFile) throws IOException {

--- a/src/test/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManagerTest.java
+++ b/src/test/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManagerTest.java
@@ -17,6 +17,9 @@
  */
 package org.fcrepo.upgrade.utils;
 
+import static org.fcrepo.upgrade.utils.RdfConstants.AUTHORIZATION;
+import static org.fcrepo.upgrade.utils.RdfConstants.FEDORA_LAST_MODIFIED_DATE;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -25,7 +28,9 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +39,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.vocabulary.RDF;
+import org.fcrepo.upgrade.utils.f6.RdfUtil;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -75,6 +83,7 @@ public class F47ToF5UpgradeManagerTest {
                          "rest/external1/fcr%3Ametadata.ttl",
                          "rest/container1.ttl",
                          "rest/container1.ttl.headers",
+                         "rest/container1/fcr%3Aacl.ttl",
                          "rest/container1/fcr%3Aversions/20201015053947.ttl",
                          "rest/container1/fcr%3Aversions/20201015053947.ttl.headers",
                          "rest/container1/fcr%3Aversions/20201015053526.ttl",
@@ -96,6 +105,14 @@ public class F47ToF5UpgradeManagerTest {
             assertTrue(f + " does not exist as expected", new File(output, f).exists());
         }
 
+        final String[] unexpectedFiles =
+            new String[]{"rest/acl.ttl",
+                         "rest/acl/authZ1.ttl",
+                         "rest/acl/authZ2.ttl"};
+
+        for (String f : unexpectedFiles) {
+            assertFalse(f + " should not exist.", new File(output, f).exists());
+        }
         //ensure external content has been transformed properly
 
         final String externalContent = FileUtils
@@ -114,22 +131,43 @@ public class F47ToF5UpgradeManagerTest {
             final var file = new File(output, f);
             if (f.contains("fcr%3Aversions")) {
 
-                if(f.endsWith(".headers")){
+                if (f.endsWith(".headers")) {
                     final Map<String, List<String>> mHeaders =
                         deserializeHeaders(file);
                     assertTrue("Memento headers do not contain memento type link header",
                                mHeaders.get("Link").stream().anyMatch(x -> x.contains("Memento")));
                     assertTrue("Memento headers do not contain Memento-Datetime header",
                                mHeaders.get("Memento-Datetime") != null);
-                } else if(f.contains("fcr:%3Ametadata")) {
-                   final var contents = IOUtils.toString(new FileInputStream(file), Charset.defaultCharset());
-                   assertTrue("Mementos should not contain links to other mementos",
-                              !contents.contains("fcr:versions/"));
+                } else if (f.contains("fcr:%3Ametadata")) {
+                    final var contents = IOUtils.toString(new FileInputStream(file), Charset.defaultCharset());
+                    assertTrue("Mementos should not contain links to other mementos",
+                               !contents.contains("fcr:versions/"));
                 }
             }
         }
 
 
+        //validate acl
+        //ensure there are two authorizations under the hash uri #auth0 and #auth1
+        final var model = RdfUtil.parseRdf(Path.of(output.toString(), "rest/container1/fcr%3Aacl.ttl"), Lang.TTL);
+        final var authSubjects = new ArrayList<String>();
+        model.listStatements().toList()
+             .stream().filter(x -> x.getPredicate().equals(RDF.type) && x.getObject().equals(AUTHORIZATION))
+             .forEach(x -> {
+                 authSubjects.add(x.getSubject().asResource().getURI());
+             });
+
+        assertEquals("There should be two authorizations.", 2, authSubjects.size());
+        assertTrue("There should be a subject with #auth0 hash uri",
+                   authSubjects.contains("http://localhost:8080/rest/container1/fcr:acl#auth0"));
+        assertTrue("There should be a subject with #auth1 hash uri",
+                   authSubjects.contains("http://localhost:8080/rest/container1/fcr:acl#auth1"));
+
+        final var lastModifiedStatement = model.listStatements().toList().stream()
+                                               .filter(x -> x.getPredicate().equals(FEDORA_LAST_MODIFIED_DATE)).findFirst().get();
+        assertTrue("There should be a last modified date", lastModifiedStatement != null);
+        assertEquals("The subject should be be the acl: ",
+                     "http://localhost:8080/rest/container1/fcr:acl", lastModifiedStatement.getSubject().getURI());
     }
 
     private Map<String, List<String>> deserializeHeaders(final File headerFile) throws IOException {

--- a/src/test/resources/4.7.5-export/rest/acl.ttl
+++ b/src/test/resources/4.7.5-export/rest/acl.ttl
@@ -1,10 +1,11 @@
 @prefix premis:  <http://www.loc.gov/premis/rdf/v1#> .
 @prefix test:  <info:fedora/test/> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix webac:  <http://fedora.info/definitions/v4/webac#> .
+@prefix ns001:  <http://www.w3.org/ns/auth/acl#> .
 @prefix xsi:  <http://www.w3.org/2001/XMLSchema-instance> .
 @prefix xmlns:  <http://www.w3.org/2000/xmlns/> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix acl:  <http://www.w3.org/ns/auth/acl#> .
 @prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
 @prefix xml:  <http://www.w3.org/XML/1998/namespace> .
 @prefix ebucore:  <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
@@ -14,18 +15,17 @@
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 @prefix dc:  <http://purl.org/dc/elements/1.1/> .
 
-<http://localhost:8080/rest/container1>
+<http://localhost:8080/rest/acl>
         rdf:type               fedora:Container ;
         rdf:type               fedora:Resource ;
+        rdf:type               webac:Acl ;
         fedora:lastModifiedBy  "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
-        dc:title               "New Title!"^^<http://www.w3.org/2001/XMLSchema#string> ;
         fedora:createdBy       "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
-        fedora:lastModified    "2020-10-15T05:39:43.383Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-        fedora:created         "2020-10-15T05:35:00.016Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-        acl:accessControl      <http://localhost:8080/rest/acl> ;
+        fedora:created         "2020-11-30T04:37:48.795Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+        fedora:lastModified    "2020-11-30T04:42:18.614Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
         rdf:type               ldp:RDFSource ;
         rdf:type               ldp:Container ;
         fedora:writable        "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
         fedora:hasParent       <http://localhost:8080/rest/> ;
-        ldp:contains           <http://localhost:8080/rest/container1/testbinary> ;
-        fedora:hasVersions     <http://localhost:8080/rest/container1/fcr:versions> .
+        ldp:contains           <http://localhost:8080/rest/acl/authZ1> ;
+        ldp:contains           <http://localhost:8080/rest/acl/authZ2> .

--- a/src/test/resources/4.7.5-export/rest/acl/authZ1.ttl
+++ b/src/test/resources/4.7.5-export/rest/acl/authZ1.ttl
@@ -1,10 +1,11 @@
 @prefix premis:  <http://www.loc.gov/premis/rdf/v1#> .
 @prefix test:  <info:fedora/test/> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix webac:  <http://fedora.info/definitions/v4/webac#> .
+@prefix ns001:  <http://www.w3.org/ns/auth/acl#> .
 @prefix xsi:  <http://www.w3.org/2001/XMLSchema-instance> .
 @prefix xmlns:  <http://www.w3.org/2000/xmlns/> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix acl:  <http://www.w3.org/ns/auth/acl#> .
 @prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
 @prefix xml:  <http://www.w3.org/XML/1998/namespace> .
 @prefix ebucore:  <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
@@ -14,18 +15,18 @@
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 @prefix dc:  <http://purl.org/dc/elements/1.1/> .
 
-<http://localhost:8080/rest/container1>
+<http://localhost:8080/rest/acl/authZ1>
         rdf:type               fedora:Container ;
+        rdf:type               ns001:Authorization ;
         rdf:type               fedora:Resource ;
+        ns001:accessTo         <http://localhost:8080/rest/container1> ;
         fedora:lastModifiedBy  "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
-        dc:title               "New Title!"^^<http://www.w3.org/2001/XMLSchema#string> ;
         fedora:createdBy       "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
-        fedora:lastModified    "2020-10-15T05:39:43.383Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-        fedora:created         "2020-10-15T05:35:00.016Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-        acl:accessControl      <http://localhost:8080/rest/acl> ;
+        fedora:created         "2020-11-30T04:38:14.522Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+        fedora:lastModified    "2020-11-30T04:38:14.522Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+        ns001:mode             ns001:Read ;
+        ns001:agent            "user1"^^<http://www.w3.org/2001/XMLSchema#string> ;
         rdf:type               ldp:RDFSource ;
         rdf:type               ldp:Container ;
         fedora:writable        "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
-        fedora:hasParent       <http://localhost:8080/rest/> ;
-        ldp:contains           <http://localhost:8080/rest/container1/testbinary> ;
-        fedora:hasVersions     <http://localhost:8080/rest/container1/fcr:versions> .
+        fedora:hasParent       <http://localhost:8080/rest/acl> .

--- a/src/test/resources/4.7.5-export/rest/acl/authZ2.ttl
+++ b/src/test/resources/4.7.5-export/rest/acl/authZ2.ttl
@@ -1,10 +1,11 @@
 @prefix premis:  <http://www.loc.gov/premis/rdf/v1#> .
 @prefix test:  <info:fedora/test/> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix webac:  <http://fedora.info/definitions/v4/webac#> .
+@prefix ns001:  <http://www.w3.org/ns/auth/acl#> .
 @prefix xsi:  <http://www.w3.org/2001/XMLSchema-instance> .
 @prefix xmlns:  <http://www.w3.org/2000/xmlns/> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix acl:  <http://www.w3.org/ns/auth/acl#> .
 @prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
 @prefix xml:  <http://www.w3.org/XML/1998/namespace> .
 @prefix ebucore:  <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
@@ -14,18 +15,19 @@
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 @prefix dc:  <http://purl.org/dc/elements/1.1/> .
 
-<http://localhost:8080/rest/container1>
+<http://localhost:8080/rest/acl/authZ2>
         rdf:type               fedora:Container ;
+        rdf:type               ns001:Authorization ;
         rdf:type               fedora:Resource ;
+        ns001:accessTo         <http://localhost:8080/rest/container1> ;
         fedora:lastModifiedBy  "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
-        dc:title               "New Title!"^^<http://www.w3.org/2001/XMLSchema#string> ;
         fedora:createdBy       "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
-        fedora:lastModified    "2020-10-15T05:39:43.383Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-        fedora:created         "2020-10-15T05:35:00.016Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-        acl:accessControl      <http://localhost:8080/rest/acl> ;
+        fedora:created         "2020-11-30T04:42:18.621Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+        fedora:lastModified    "2020-11-30T04:42:18.621Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+        ns001:mode             ns001:Write ;
+        ns001:mode             ns001:Read ;
+        ns001:agent            "user2"^^<http://www.w3.org/2001/XMLSchema#string> ;
         rdf:type               ldp:RDFSource ;
         rdf:type               ldp:Container ;
         fedora:writable        "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
-        fedora:hasParent       <http://localhost:8080/rest/> ;
-        ldp:contains           <http://localhost:8080/rest/container1/testbinary> ;
-        fedora:hasVersions     <http://localhost:8080/rest/container1/fcr:versions> .
+        fedora:hasParent       <http://localhost:8080/rest/acl> .


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-2985

**Adds support for upgrading ACLs from 4.7.5 to 5.x**
* * *

**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-2985

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
On upgrading to 4.7.5, this PR essentially performs the transforms necessary to bring the 4.7.5 acls into alignment with 5.x.
What that means is the following: 
1.  on the protected resource the "acl:accessControl" predicate is removed.
2. the object to which the aforementioned predicate points is imported using the following steps:
     a. Verify that the resource is of type "webac#Acl"
     b. Create new acl in the proper location (under the protected resource at "resource/fcr:acl")
     c. Recurse the child resources of the original ACL and add any authorizations  to the new ACL using hash URIs in the subjects.
 
# How should this be tested?

1.  Run fcrepo 4.7.5.
```
java -jar fcrepo-webapp-4.7.5-jetty-console.jar --headless
```
2. Create a resource and an ACL
```
# create resource
curl -u fedoraAdmin:fedoraAdmin -X PUT http://localhost:8080/rest/container1 --data "" -H "Content-Type: text/turtle"

# create acl
curl -u fedoraAdmin:fedoraAdmin -X PUT http://localhost:8080/rest/acl --data "<> a <http://fedora.info/definitions/v4/webac#Acl> ." -H "Content-Type: text/turtle"

# attach acl to resource
curl -u fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/container1" -X PATCH -H "Content-Type: application/sparql-update" --data "INSERT DATA { <http://localhost:8080/rest/container1> <http://www.w3.org/ns/auth/acl#accessControl> <http://localhost:8080/rest/acl>. }"

```
3. Create two authorizations
auth0.ttl
```
@prefix acl: <http://www.w3.org/ns/auth/acl#>.

<> a acl:Authorization;
   acl:accessTo </fcrepo/rest/container1>;
   acl:agent "testuser";
   acl:mode acl:Read.
```
PUT it.
```
curl -u fedoraAdmin:fedoraAdmin -X PUT -H "Content-Type: turtle/text" http://localhost:8080/rest/acl/auth0 --data "@auth0.ttl"
```

auth1.ttl
```
@prefix acl: <http://www.w3.org/ns/auth/acl#>.

<> a acl:Authorization;
   acl:accessTo </fcrepo/rest/container1>;
   acl:agent "testuser2";
   acl:mode acl:Read.
```
PUT it:
```
curl -u fedoraAdmin:fedoraAdmin -X PUT -H "Content-Type: turtle/text" http://localhost:8080/rest/acl/auth1 --data "@auth1.ttl"
```

5. Perform an export using fcrepo-import-export-0.3.0
```
java -jar fcrepo-import-export-0.3.0.jar -b -d 4.7.5-export -u fedoraAdmin:fedoraAdmin  -m export -r http://localhost:8080/rest  
```
6. Upgrade from 4.7.5 to 5.x
```
java -Dfcrepo.log=DEBUG -jar ~/code/fcrepo-upgrade-utils/target/fcrepo-upgrade-utils-6.0.0-SNAPSHOT.jar -i 4.7.5-export -o 5.1.1-export  -s 4.7.5 -t 5+ -u  http://localhost:8080/rest
```

7. Upgrade from 5.x to 6.
```
java -Dfcrepo.log=DEBUG -jar fcrepo-upgrade-utils-6.0.0-SNAPSHOT.jar -i 5.1.1-export  -o fcrepo-6-home/data -s 5+ -t 6+ -u http://localhost:8080/rest
```
8. Stop Fedora 4.7.5 
9. Start Fedora 6.0.0 (with the testuser configured using the fedoraUser role) setting your fcrepo.home to `fcrepo-6-home`

10. Verify that the ACL has been migrated and the old ACL and Authorizations no longer exist: 
```
# expect 404s:
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/acl
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/acl/auth0
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/acl/auth1

# expect 202
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/container1/fcr:acl

# validate that the acls have been merged (you should see hash uris  with the following subjects: 
http://localhost:8080/rest/container1/fcr:acl#auth0
http://localhost:8080/rest/container1/fcr:acl#auth1

# Make sure the ACL works:
curl -u -v fedoraAdmin:fedoraAdmin http://localhost:8080/rest/container1  # 200
curl -u -v testuser:password1 http://localhost:8080/rest/container1  # 200
curl -u -X PUT -v testuser:password1 http://localhost:8080/rest/container1  # 401
curl -u -X PUT -v fedoraAdmin:fedoraAdmin http://localhost:8080/rest/container1  # 201


```



# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
