### PR TITLE
upgrade to ocfl-java 0.2

### DIFF
--- a/src/main/java/org/fcrepo/upgrade/utils/UpgradeManagerFactory.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/UpgradeManagerFactory.java
@@ -25,7 +25,7 @@ import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import edu.wisc.library.ocfl.api.OcflConfig;
 import edu.wisc.library.ocfl.api.model.DigestAlgorithm;
 import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
-import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedTruncatedNTupleConfig;
+import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedNTupleLayoutConfig;
 import edu.wisc.library.ocfl.core.path.mapper.LogicalPathMappers;
 import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.apache.commons.lang3.SystemUtils;
@@ -106,7 +106,7 @@ public class UpgradeManagerFactory {
         final var digestAlgorithm = DigestAlgorithm.fromOcflName(config.getDigestAlgorithm());
 
         return new OcflRepositoryBuilder()
-                .layoutConfig(new HashedTruncatedNTupleConfig())
+                .defaultLayoutConfig(new HashedNTupleLayoutConfig())
                 .ocflConfig(new OcflConfig()
                         .setDefaultDigestAlgorithm(digestAlgorithm))
                 .logicalPathMapper(logicalPathMapper)

--- a/src/test/java/org/fcrepo/upgrade/utils/F5ToF6UpgradeManagerTest.java
+++ b/src/test/java/org/fcrepo/upgrade/utils/F5ToF6UpgradeManagerTest.java
@@ -101,9 +101,11 @@ public class F5ToF6UpgradeManagerTest {
     }
 
     private Set<String> listAllFiles(final Path root) {
+        final var storageExtensions = root.resolve("extensions");
         try (final var files = Files.walk(root)) {
             return files.filter(Files::isRegularFile)
                     .filter(f -> !f.getParent().equals(root))
+                    .filter(f -> !f.getParent().getParent().equals(storageExtensions))
                     .map(f -> root.relativize(f).toString())
                     .collect(Collectors.toSet());
         } catch (IOException e) {


### PR DESCRIPTION
**Jira:** https://jira.lyrasis.org/browse/FCREPO-3590

**This PR depends on https://github.com/fcrepo/fcrepo-storage-ocfl/pull/27**

Upgrades ocfl-java to the latest version.

A key difference in this version is that the storage layout extension definition is moved into the `extensions` directory. While the layout extension we're using has not been merged yet, it is unlikely that it'll need to be updated again.

This change does mean that the layout config in the storage root will no longer be read. Existing repositories with the storage layout in the old location are still usable, but `ocfl-java` will **not** write the storage layout to the new location for an existing repository. You either need to recreate the repository or write it manually.

To manually create it, write the following to `ocfl-root/extensions/0004-hashed-n-tuple-storage-layout/config.json`:

```json
{
  "digestAlgorithm" : "sha256",
  "tupleSize" : 3,
  "numberOfTuples" : 3,
  "shortObjectRoot" : false,
  "extensionName" : "0004-hashed-n-tuple-storage-layout"
}
```

