### PR TITLE
Make digest algorithm more configurable

### DIFF
--- a/src/main/java/org/fcrepo/upgrade/utils/Config.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/Config.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import org.apache.jena.riot.Lang;
 
 import java.io.File;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -33,6 +34,7 @@ public class Config {
     public static final String DEFAULT_USER = "fedoraAdmin";
     public static final String DEFAULT_USER_ADDRESS = "info:fedora/fedoraAdmin";
     public static final String DEFAULT_DIGEST_ALGORITHM = "sha512";
+    public static final List<String> VALID_DIGEST_ALGORITHMS = List.of(DEFAULT_DIGEST_ALGORITHM, "sha256");
     public static final Lang DEFAULT_SRC_RDF_LANG = Lang.TTL;
     public static final int DEFAULT_THREADS = Runtime.getRuntime().availableProcessors();
 
@@ -45,7 +47,7 @@ public class Config {
     private Lang srcRdfLang = DEFAULT_SRC_RDF_LANG;
     private String baseUri;
     private Integer threads = DEFAULT_THREADS;
-    private String digestAlgorithm = DEFAULT_DIGEST_ALGORITHM;
+    private String digestAlgorithm;
     private String fedoraUser = DEFAULT_USER;
     private String fedoraUserAddress = DEFAULT_USER_ADDRESS;
     private boolean forceWindowsMode = false;
@@ -157,6 +159,9 @@ public class Config {
      * @return the digest algorithm to use in OCFL, sha512 or sha256
      */
     public String getDigestAlgorithm() {
+        if (this.digestAlgorithm == null) {
+            return DEFAULT_DIGEST_ALGORITHM;
+        }
         return digestAlgorithm;
     }
 
@@ -165,11 +170,7 @@ public class Config {
      * @param digestAlgorithm sha512 or sha256
      */
     public void setDigestAlgorithm(final String digestAlgorithm) {
-        if (digestAlgorithm == null) {
-            this.digestAlgorithm = DEFAULT_DIGEST_ALGORITHM;
-        } else {
-            this.digestAlgorithm = digestAlgorithm;
-        }
+        this.digestAlgorithm = digestAlgorithm;
     }
 
     /**

--- a/src/main/java/org/fcrepo/upgrade/utils/UpgradeUtilDriver.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/UpgradeUtilDriver.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static org.fcrepo.upgrade.utils.Config.VALID_DIGEST_ALGORITHMS;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -157,7 +158,14 @@ public class UpgradeUtilDriver {
         }
 
         config.setBaseUri(cmd.getOptionValue("base-uri"));
-        config.setDigestAlgorithm(cmd.getOptionValue("digest-algorithm"));
+        if (cmd.hasOption("digest-algorithm")) {
+            final var algo = cmd.getOptionValue("digest-algorithm");
+            if (!VALID_DIGEST_ALGORITHMS.contains(algo)) {
+                printHelpAndExit(format("invalid digest algorithm (%s) provided, must be one of %s",
+                        algo, String.join(", ", VALID_DIGEST_ALGORITHMS)), configOptions);
+            }
+            config.setDigestAlgorithm(cmd.getOptionValue("digest-algorithm"));
+        }
         config.setFedoraUser(cmd.getOptionValue("migration-user"));
         config.setFedoraUserAddress(cmd.getOptionValue("migration-user-address"));
 
@@ -262,14 +270,14 @@ public class UpgradeUtilDriver {
         return configOptions;
     }
 
-    private Object join(Collection<FedoraVersion> versions) {
-        return versions.stream().map(x -> x.getStringValue()).collect(Collectors.joining(","));
+    private Object join(final Collection<FedoraVersion> versions) {
+        return versions.stream().map(FedoraVersion::getStringValue).collect(Collectors.joining(","));
     }
 
     private static void printHelpAndExit(final String errorMessage, final Options options) {
         final HelpFormatter formatter = new HelpFormatter();
         System.err.println(errorMessage);
-        formatter.printHelp("fcepo-upgrade-util", options);
+        formatter.printHelp("java -jar fcrepo-upgrade-util-<version>.jar", options);
         System.exit(1);
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3583

# What does this Pull Request do?
There was already a configuration option, I just did some simple validation.

# How should this be tested?

Run a 5 to 6 migration as normal see sha512 hashes in the inventory.json files.
Run a 5 to 6 migration with the argument `-d sha256` or `--digest-algorithm sha256` and see sha256 in the inventory.json files.
Run a 5 to 6 migration with the argument `-d` or `--digest-algorithm` set to anything else and get an error.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo-exts/committers
