### PR TITLE
Ensures that the parameter baseUri is only required when upgrading to F6

### DIFF
--- a/src/main/java/org/fcrepo/upgrade/utils/UpgradeUtilDriver.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/UpgradeUtilDriver.java
@@ -157,7 +157,10 @@ public class UpgradeUtilDriver {
             config.setThreads(Integer.valueOf(cmd.getOptionValue("threads")));
         }
 
-        config.setBaseUri(cmd.getOptionValue("base-uri"));
+        if (config.getTargetVersion().equals(FedoraVersion.V_6)) {
+            //base URI only used when migrating to F6
+            config.setBaseUri(cmd.getOptionValue("base-uri"));
+        }
         if (cmd.hasOption("digest-algorithm")) {
             final var algo = cmd.getOptionValue("digest-algorithm");
             if (!VALID_DIGEST_ALGORITHMS.contains(algo)) {


### PR DESCRIPTION


**Ensures that the parameter baseUri is only required when upgrading to F6**
* * *

**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3599

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Previously fcrepo-upgrade-utils was requiring the --base-uri on an f4->f5 upgrade even though the property is only used in the f5->f6 migration.

# How should this be tested?

```
java -jar target/fcrepo-upgrade-utils-6.0.0-SNAPSHOT.jar -s 5+ -t 6+ -i /tmp/empty-dir
```
Should exit with the following log message: 
```
ERROR 13:58:49.418 (UpgradeUtilDriver) Error performing upgrade: baseUri must be specified
```

While 
```
java -jar target/fcrepo-upgrade-utils-6.0.0-SNAPSHOT.jar -s 4.7.5 -t 5+ -i /tmp/empty-dir
```
should succeed.

Before this update, the previous command failed with the "Error performing upgrade: baseUri must be specified" message.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? 
* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
