### PR TITLE
added support for resuming F6 migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ usage: java -jar fcrepo-upgrade-util-<version>.jar
                                      cores
  -r,--source-rdf <arg>               The RDF language used in the Fedora
                                      export. Default: Turtle
- -R,--resource-info-file <arg>       The path the file that contains a
+ -R,--resource-info-file <arg>       The path of the file that contains a
                                      list of resources to be processed
  -s,--source-version <arg>           The version of Fedora that was the
                                      source of the export. Valid values:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ usage: java -jar fcrepo-upgrade-util-<version>.jar
                                      cores
  -r,--source-rdf <arg>               The RDF language used in the Fedora
                                      export. Default: Turtle
+ -R,--resource-info-file <arg>       The path the file that contains a
+                                     list of resources to be processed
  -s,--source-version <arg>           The version of Fedora that was the
                                      source of the export. Valid values:
                                      5+,4.7.5
@@ -60,6 +62,21 @@ usage: java -jar fcrepo-upgrade-util-<version>.jar
     --write-to-s3                    Enables writing migrated Fedora 6
                                      data to S3 rather than the local
                                      filesystem
+```
+
+### Resuming Fedora 6 Migration
+
+If a Fedora 6 migration is interrupted or a subset of resources fail to migrate, then a log file named
+`remaining_TIMESTAMP.log` is created that contains information about the resources that were not migrated. The
+migration can be resumed by passing this file back to the utility on a subsequent run. For example:
+
+```shell
+java -jar fcrepo-upgrade-utils.jar \
+  --input-dir my-5.1.1-export \
+  --source-version 5+ \
+  --target-version 6+ \
+  --base-uri http://localhost:8080/rest \
+  --resource-info-file remaining_TIMESTAMP.log
 ```
 
 ### S3

--- a/src/main/java/org/fcrepo/upgrade/utils/Config.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/Config.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import org.apache.jena.riot.Lang;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 
@@ -51,6 +52,7 @@ public class Config {
     private String fedoraUser = DEFAULT_USER;
     private String fedoraUserAddress = DEFAULT_USER_ADDRESS;
     private boolean forceWindowsMode = false;
+    private Path resourceInfoFile;
 
     // S3 Options
     private boolean writeToS3;
@@ -370,6 +372,20 @@ public class Config {
         this.s3Prefix = s3Prefix;
     }
 
+    /**
+     * @return path to the resource info file or null
+     */
+    public Path getResourceInfoFile() {
+        return resourceInfoFile;
+    }
+
+    /**
+     * @param resourceInfoFile path to the resource info file
+     */
+    public void setResourceInfoFile(Path resourceInfoFile) {
+        this.resourceInfoFile = resourceInfoFile;
+    }
+
     @Override
     public String toString() {
         return "Config{" +
@@ -390,6 +406,7 @@ public class Config {
                 ", s3PathStyleAccess=" + s3PathStyleAccess +
                 ", s3Bucket=" + s3Bucket +
                 ", s3Prefix=" + s3Prefix +
+                ", resourceInfoFile=" + resourceInfoFile +
                 '}';
     }
 

--- a/src/main/java/org/fcrepo/upgrade/utils/UpgradeUtilDriver.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/UpgradeUtilDriver.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.riot.RDFLanguages;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Collection;
@@ -181,6 +182,10 @@ public class UpgradeUtilDriver {
         config.setS3SecretKey(cmd.getOptionValue("s3-secret-key"));
         config.setS3Bucket(cmd.getOptionValue("s3-bucket"));
         config.setS3Prefix(cmd.getOptionValue("s3-prefix"));
+
+        if (cmd.getOptionValue('R') != null) {
+            config.setResourceInfoFile(Paths.get(cmd.getOptionValue('R')));
+        }
 
         if (config.getTargetVersion() == FedoraVersion.V_6) {
             if (config.getBaseUri() == null) {
@@ -339,6 +344,13 @@ public class UpgradeUtilDriver {
                 .longOpt("s3-secret-key")
                 .hasArg(true)
                 .desc("The AWS secret key, optionally use when writing to S3")
+                .required(false)
+                .build());
+
+        configOptions.addOption(Option.builder("R")
+                .longOpt("resource-info-file")
+                .hasArg(true)
+                .desc("The path the file that contains a list of resources to be processed")
                 .required(false)
                 .build());
 

--- a/src/main/java/org/fcrepo/upgrade/utils/f6/ResourceInfo.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/f6/ResourceInfo.java
@@ -200,13 +200,14 @@ public class ResourceInfo {
         return Objects.equals(parentId, that.parentId)
                 && Objects.equals(fullId, that.fullId)
                 && Objects.equals(nameEncoded, that.nameEncoded)
-                && Objects.equals(outerDirectory, that.outerDirectory)
-                && Objects.equals(innerDirectory, that.innerDirectory)
+                && Objects.equals(outerDirectory.toAbsolutePath(), that.outerDirectory.toAbsolutePath())
+                && Objects.equals(innerDirectory.toAbsolutePath(), that.innerDirectory.toAbsolutePath())
                 && type == that.type;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(parentId, fullId, nameEncoded, outerDirectory, innerDirectory, type);
+        return Objects.hash(parentId, fullId, nameEncoded,
+                outerDirectory.toAbsolutePath(), innerDirectory.toAbsolutePath(), type);
     }
 }

--- a/src/main/java/org/fcrepo/upgrade/utils/f6/ResourceInfo.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/f6/ResourceInfo.java
@@ -18,7 +18,11 @@
 
 package org.fcrepo.upgrade.utils.f6;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.nio.file.Path;
+import java.util.Objects;
 
 /**
  * Encapsulates all of the information necessary to migrate a resource.
@@ -33,13 +37,27 @@ public class ResourceInfo {
         CONTAINER,
     }
 
-
     private final String parentId;
     private final String fullId;
     private final String nameEncoded;
     private final Path outerDirectory;
     private final Path innerDirectory;
     private final Type type;
+
+    /**
+     * Used by Jackson for deserialization
+     *
+     * @return resource info object
+     */
+    @JsonCreator
+    public static ResourceInfo deserialize(@JsonProperty("parentId") final String parentId,
+                                           @JsonProperty("fullId") final String fullId,
+                                           @JsonProperty("nameEncoded") final String nameEncoded,
+                                           @JsonProperty("outerDirectory") final Path outerDirectory,
+                                           @JsonProperty("innerDirectory") final Path innerDirectory,
+                                           @JsonProperty("type") final Type type) {
+        return new ResourceInfo(parentId, fullId, outerDirectory, innerDirectory, nameEncoded, type);
+    }
 
     /**
      * Create a ResourceInfo instance for a container resource
@@ -92,6 +110,20 @@ public class ResourceInfo {
     private ResourceInfo(final String parentId,
                          final String fullId,
                          final Path outerDirectory,
+                         final String nameEncoded,
+                         final Type type) {
+        this.parentId = parentId;
+        this.fullId = fullId;
+        this.nameEncoded = nameEncoded;
+        this.outerDirectory = outerDirectory;
+        this.innerDirectory = outerDirectory.resolve(nameEncoded);
+        this.type = type;
+    }
+
+    private ResourceInfo(final String parentId,
+                         final String fullId,
+                         final Path outerDirectory,
+                         final Path innerDirectory,
                          final String nameEncoded,
                          final Type type) {
         this.parentId = parentId;
@@ -156,4 +188,25 @@ public class ResourceInfo {
                 '}';
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ResourceInfo that = (ResourceInfo) o;
+        return Objects.equals(parentId, that.parentId)
+                && Objects.equals(fullId, that.fullId)
+                && Objects.equals(nameEncoded, that.nameEncoded)
+                && Objects.equals(outerDirectory, that.outerDirectory)
+                && Objects.equals(innerDirectory, that.innerDirectory)
+                && type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parentId, fullId, nameEncoded, outerDirectory, innerDirectory, type);
+    }
 }

--- a/src/main/java/org/fcrepo/upgrade/utils/f6/ResourceInfoLogger.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/f6/ResourceInfoLogger.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.upgrade.utils.f6;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Logs ResourceInfo objects to a file
+ *
+ * @author pwinckles
+ */
+public class ResourceInfoLogger {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ResourceInfoLogger.class);
+    private static final Logger INFO_LOG = LoggerFactory.getLogger("org.fcrepo.upgrade.utils.remaining");
+
+    private final ObjectMapper objectMapper;
+
+    public ResourceInfoLogger() {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    /**
+     * Logs the resource info to the remaining log file.
+     *
+     * @param info resource info to log
+     */
+    public void log(final ResourceInfo info) {
+        try {
+            INFO_LOG.error("{}", objectMapper.writeValueAsString(info));
+        } catch (JsonProcessingException e) {
+            LOG.error("Failed to serialize {} to remaining log", info, e);
+        }
+    }
+
+    /**
+     * Parses a log file that contains JSON serialized ResourceInfo objects, one per line, into a list of objects
+     *
+     * @param logPath log file to parse
+     * @return list of parsed objects
+     */
+    public List<ResourceInfo> parseLog(final Path logPath) {
+        final var infos = new ArrayList<ResourceInfo>();
+
+        try (final var reader = new BufferedReader(new InputStreamReader(Files.newInputStream(logPath)))) {
+            while (reader.ready()) {
+                infos.add(objectMapper.readValue(reader.readLine(), ResourceInfo.class));
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        return infos;
+    }
+
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,11 +7,36 @@
         </encoder>
     </appender>
 
+    <timestamp key="bySecond" datePattern="yyyyMMdd'T'HHmmss"/>
+
+    <!-- This appender is used to create a file that contains URIs of resources that were not migrated
+         either due to failure or early termination -->
+    <appender name="REMAINING" class="ch.qos.logback.classic.sift.SiftingAppender">
+        <discriminator>
+            <Key>defaultKey</Key>
+            <defaultValue>defaultValue</defaultValue>
+        </discriminator>
+        <sift>
+            <appender name="REMAINING-INNER" class="ch.qos.logback.core.FileAppender">
+                <!-- use the previously created timestamp to create a uniquely
+                  named log file -->
+                <file>${PWD}/remaining_${bySecond}.log</file>
+                <prudent>true</prudent>
+                <encoder>
+                    <pattern>%msg%n</pattern>
+                </encoder>
+            </appender>
+        </sift>
+    </appender>
+
   <logger name="org.fcrepo.kernel" additivity="false" level="${fcrepo.log.utils:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
   <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
     <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.fcrepo.upgrade.utils.remaining" additivity="false" level="INFO">
+      <appender-ref ref="REMAINING"/>
   </logger>
 
   <root additivity="false" level="WARN">

--- a/src/test/java/org/fcrepo/upgrade/utils/f6/MigrationTaskManagerTest.java
+++ b/src/test/java/org/fcrepo/upgrade/utils/f6/MigrationTaskManagerTest.java
@@ -68,7 +68,7 @@ public class MigrationTaskManagerTest {
         defaultInfo = ResourceInfo.container(parent, join(parent, "child"), Paths.get("/"), "child");
         logPath = Paths.get("target/remaining.log");
         if (Files.exists(logPath)) {
-            Files.write(logPath, new byte[0], StandardOpenOption.TRUNCATE_EXISTING);
+            Files.write(logPath, new byte[0], StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.SYNC);
         }
     }
 

--- a/src/test/java/org/fcrepo/upgrade/utils/f6/MigrationTaskManagerTest.java
+++ b/src/test/java/org/fcrepo/upgrade/utils/f6/MigrationTaskManagerTest.java
@@ -68,7 +68,7 @@ public class MigrationTaskManagerTest {
         defaultInfo = ResourceInfo.container(parent, join(parent, "child"), Paths.get("/"), "child");
         logPath = Paths.get("target/remaining.log");
         if (Files.exists(logPath)) {
-            Files.write(logPath, new byte[0], StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.SYNC);
+            Files.write(logPath, new byte[0], StandardOpenOption.TRUNCATE_EXISTING);
         }
     }
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -7,11 +7,26 @@
         </encoder>
     </appender>
 
+    <!-- This appender is used to create a file that contains URIs of resources that were not migrated
+       either due to failure or early termination -->
+    <appender name="REMAINING" class="ch.qos.logback.core.FileAppender">
+        <!-- use the previously created timestamp to create a uniquely
+          named log file -->
+        <file>target/remaining.log</file>
+        <prudent>true</prudent>
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
   <logger name="org.fcrepo.kernel" additivity="false" level="${fcrepo.log.upgrade.utils:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
   <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
     <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.fcrepo.upgrade.utils.remaining" additivity="false" level="INFO">
+      <appender-ref ref="REMAINING"/>
   </logger>
 
   <root additivity="false" level="WARN">


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3426

# What does this Pull Request do?

1. Adds a log that contains information about resources that fail to migrate or that were waiting to be migrated
2. Adds a CLI options for passing in the above file to resume a migration

# How should this be tested?

1. Attempt to migrate an F5 export to F6
2. Kill (ctrl+c) the export while it's still running
3. See the `remaining_TIMESTAMP.log` file that was generated
4. Pass this file back to the migrate command using `-R`
5. See it pickup where it left off

# Interested parties

@fcrepo/committers
