### PR TITLE
resources that have already been migrated will not be migrated again

### DIFF
--- a/src/test/java/org/fcrepo/upgrade/utils/f6/ResourceMigratorTest.java
+++ b/src/test/java/org/fcrepo/upgrade/utils/f6/ResourceMigratorTest.java
@@ -97,6 +97,16 @@ public class ResourceMigratorTest {
     }
 
     @Test
+    public void migratingResourceTwiceShouldDoNothing() {
+        final var info = binaryInfo("simple-binary");
+
+        migrateNoChildren(info);
+        migrateNoChildren(info);
+
+        assertResourcesSame(info);
+    }
+
+    @Test
     public void migrateExternalBinaryProxied() {
         final var info = externalBinaryInfo("external-proxied");
 
@@ -127,6 +137,21 @@ public class ResourceMigratorTest {
     public void migrateBasicContainerWithChildren() {
         final var info = containerInfo("container-with-children");
 
+        final var children = migrate(info);
+
+        assertEquals(2, children.size());
+
+        assertChildInfo(info, "binary-child", ResourceInfo.Type.BINARY, children.get(0));
+        assertChildInfo(info, "container-child", ResourceInfo.Type.CONTAINER, children.get(1));
+
+        assertResourcesSame(info);
+    }
+
+    @Test
+    public void migrateBasicContainerWithChildrenTwiceShouldDoNothingButReturnChildren() {
+        final var info = containerInfo("container-with-children");
+
+        migrate(info);
         final var children = migrate(info);
 
         assertEquals(2, children.size());


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3748

# What does this Pull Request do?

1. Rerunning a migration to the same output location will _not_ migrate resources that already exist in the destination

# How should this be tested?

1. Run a normal migration
2. Run the same migration again and see that it did not touch any of the migrated resources

# Interested parties

@fcrepo/committers
