### PR TITLE
upgrade ocfl-java; add buffers to streams

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <fcrepo.storage.ocfl.version>6.0.0</fcrepo.storage.ocfl.version>
     <commons-lang.version>3.11</commons-lang.version>
     <commons-collections.version>4.4</commons-collections.version>
-    <ocfl-java.version>1.1.0</ocfl-java.version>
+    <ocfl-java.version>1.2.3</ocfl-java.version>
     <httpclient.version>4.5.13</httpclient.version>
   </properties>
 

--- a/src/main/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManager.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManager.java
@@ -42,11 +42,13 @@ import static org.fcrepo.upgrade.utils.RdfConstants.MEMENTO;
 import static org.fcrepo.upgrade.utils.RdfConstants.NON_RDF_SOURCE_DESCRIPTION;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.ZoneId;
@@ -168,7 +170,7 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
         throws IOException {
         //parse the file
         final Model model = ModelFactory.createDefaultModel();
-        try (final FileInputStream is = new FileInputStream(newLocation.toFile())) {
+        try (final InputStream is = new BufferedInputStream(new FileInputStream(newLocation.toFile()))) {
             RDFDataMgr.read(model, is, Lang.TTL);
         }
 
@@ -463,7 +465,7 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
 
     private Model createModelFromFile(final Path path) {
         final Model model = ModelFactory.createDefaultModel();
-        try (final FileInputStream is = new FileInputStream(path.toFile())) {
+        try (final InputStream is = new BufferedInputStream(new FileInputStream(path.toFile()))) {
             RDFDataMgr.read(model, is, Lang.TTL);
         } catch (IOException ex) {
             throw new RuntimeException(ex);

--- a/src/main/java/org/fcrepo/upgrade/utils/f6/RdfUtil.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/f6/RdfUtil.java
@@ -35,6 +35,7 @@ import org.apache.jena.vocabulary.RDF;
 import org.fcrepo.upgrade.utils.RdfConstants;
 import org.slf4j.Logger;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -72,7 +73,7 @@ public final class RdfUtil {
      */
     public static Model parseRdf(final Path path, final Lang lang) {
         final var model = ModelFactory.createDefaultModel();
-        try (final var is = Files.newInputStream(path)) {
+        try (final var is = new BufferedInputStream(Files.newInputStream(path))) {
             RDFDataMgr.read(model, is, lang);
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/src/main/java/org/fcrepo/upgrade/utils/f6/ResourceMigrator.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/f6/ResourceMigrator.java
@@ -23,6 +23,7 @@ import static org.fcrepo.upgrade.utils.RdfConstants.FEDORA_CREATED_DATE;
 import static org.fcrepo.upgrade.utils.RdfConstants.FEDORA_LAST_MODIFIED_DATE;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -244,7 +245,7 @@ public class ResourceMigrator {
         final var descId = joinId(info.getFullId(), FCR_METADATA_ID);
         final var descHeaders = createBinaryDescHeaders(info.getFullId(), descId, rdf);
 
-        try (final var stream = Files.newInputStream(binaryFile)) {
+        try (final var stream = new BufferedInputStream(Files.newInputStream(binaryFile))) {
             writeBinary(info.getFullId(), binaryDir, headers, stream, descHeaders, rdf, timestamp);
         } catch (IOException e) {
             throw new UncheckedIOException(e);


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3758

**This PR depends on https://github.com/fcrepo/fcrepo-storage-ocfl/pull/43**

# What does this Pull Request do?

Upgrades to the latest version of ocfl-java and adds buffers to a few input streams. The latest version of ocfl-java adds buffering to all input streams, including streams that are returned via the api. This will resolve a couple of buffering related bugs in this code base as well, and hopefully make it much faster on systems running on a NAS.

# How should this be tested?

No functional changes

# Interested parties
@fcrepo/committers