### PR TITLE
updating actions/cache github action as v2 is being deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         java-version: 11
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION

**JIRA Ticket**: https://github.com/actions/toolkit/tree/main/packages/cache

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
bumps actions/cache from v2 to v4


# What's new?
A in-depth description of the changes made by this PR. Technical details and possible side effects.

Example:
* Changes x feature to such that y
* Added x
* Removed y

# How should this be tested?
Check GH Actions still run as expected. The action is supposedly backwards compatible so no issues are expected

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
