### PR TITLE
Add option to skip special handling of Acls

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ usage: java -jar fcrepo-upgrade-util-<version>.jar
                                      export. Default: Turtle
  -R,--resource-info-file <arg>       The path of the file that contains a
                                      list of resources to be processed
+    --skip-acls                      Skip creating fcr:acl resources
+                                     and migrate webac:Acl and
+                                     acl:Authorization resources normally
  -s,--source-version <arg>           The version of Fedora that was the
                                      source of the export. Valid values:
                                      5+,4.7.5

--- a/src/main/java/org/fcrepo/upgrade/utils/Config.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/Config.java
@@ -41,6 +41,7 @@ public class Config {
     private String fedoraUserAddress = DEFAULT_USER_ADDRESS;
     private boolean forceWindowsMode = false;
     private Path resourceInfoFile;
+    private boolean skipAcls = false;
 
     // S3 Options
     private boolean writeToS3;
@@ -256,6 +257,20 @@ public class Config {
     }
 
     /**
+     * @return true if should skip special handling of acl resources
+     */
+    public boolean isSkipAcls() {
+        return skipAcls;
+    }
+
+    /**
+     * @param skipAcls true if should skip special handling of acl resources
+     */
+    public void setSkipAcls(final boolean skipAcls) {
+        this.skipAcls = skipAcls;
+    }
+
+    /**
      * @return true if should write migrated resources to S3
      */
     public boolean isWriteToS3() {
@@ -395,6 +410,7 @@ public class Config {
                 ", fedoraUser='" + fedoraUser + '\'' +
                 ", fedoraUserAddress='" + fedoraUserAddress + '\'' +
                 ", forceWindowsMode=" + forceWindowsMode +
+                ", skipAcls=" + skipAcls +
                 ", writeToS3=" + writeToS3 +
                 ", s3Region='" + s3Region + '\'' +
                 ", s3Endpoint='" + s3Endpoint + '\'' +

--- a/src/main/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManager.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManager.java
@@ -181,7 +181,7 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
 
         //skip if ACL or Authorization: these files are upgraded through a separate code path
         // see convertAcl() below.
-        if (rdfTypes.contains(ACL) || rdfTypes.contains(AUTHORIZATION)) {
+        if (!this.config.isSkipAcls() && (rdfTypes.contains(ACL) || rdfTypes.contains(AUTHORIZATION))) {
             newLocation.toFile().delete();
             return;
         }
@@ -250,7 +250,7 @@ class F47ToF5UpgradeManager extends UpgradeManagerBase implements UpgradeManager
                     }
                 }
                 binaryHeaders.put(CONTENT_TYPE_HEADER, Collections.singletonList(mimetype));
-            } else if (statement.getPredicate().equals(ACCESS_CONTROL)) {
+            } else if (!this.config.isSkipAcls() && statement.getPredicate().equals(ACCESS_CONTROL)) {
                 //remove the current statement across both past versions and latest version
                 model.remove(currentStatement);
                 rewriteModel.set(true);

--- a/src/main/java/org/fcrepo/upgrade/utils/UpgradeUtilDriver.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/UpgradeUtilDriver.java
@@ -168,6 +168,8 @@ public class UpgradeUtilDriver {
         config.setFedoraUser(cmd.getOptionValue("migration-user"));
         config.setFedoraUserAddress(cmd.getOptionValue("migration-user-address"));
 
+        config.setSkipAcls(cmd.hasOption("skip-acls"));
+
         config.setWriteToS3(cmd.hasOption("write-to-s3"));
         config.setS3Region(cmd.getOptionValue("s3-region"));
         config.setS3Endpoint(cmd.getOptionValue("s3-endpoint"));
@@ -280,6 +282,12 @@ public class UpgradeUtilDriver {
                 .hasArg(true)
                 .desc("The address of the user OCFL versions are attributed to. Default: "
                         + Config.DEFAULT_USER_ADDRESS)
+                .required(false)
+                .build());
+        configOptions.addOption(Option.builder()
+                .longOpt("skip-acls")
+                .hasArg(false)
+                .desc("Skip creating fcr:acl resources and migrate webac:Acl and acl:Authorization resources normally")
                 .required(false)
                 .build());
 

--- a/src/test/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManagerTest.java
+++ b/src/test/java/org/fcrepo/upgrade/utils/F47ToF5UpgradeManagerTest.java
@@ -5,6 +5,7 @@
  */
 package org.fcrepo.upgrade.utils;
 
+import static org.fcrepo.upgrade.utils.RdfConstants.ACCESS_CONTROL;
 import static org.fcrepo.upgrade.utils.RdfConstants.AUTHORIZATION;
 import static org.fcrepo.upgrade.utils.RdfConstants.FEDORA_LAST_MODIFIED_DATE;
 import static org.junit.Assert.assertEquals;
@@ -155,7 +156,7 @@ public class F47ToF5UpgradeManagerTest {
                                                .filter(x -> x.getPredicate().equals(FEDORA_LAST_MODIFIED_DATE))
                                                .findFirst().get();
         assertTrue("There should be a last modified date", lastModifiedStatement != null);
-        assertEquals("The subject should be be the acl: ",
+        assertEquals("The subject should be the acl: ",
                      "http://localhost:8080/rest/container1/fcr:acl",
                      lastModifiedStatement.getSubject().getURI());
     }
@@ -248,7 +249,6 @@ public class F47ToF5UpgradeManagerTest {
             }
         }
 
-
         //validate acl
         //ensure there are two authorizations under the hash uri #auth0 and #auth1
         final var model = RdfUtil.parseRdf(Path.of(output.toString(), "rest/container1/fcr%3Aacl.nt"), Lang.TTL);
@@ -272,6 +272,72 @@ public class F47ToF5UpgradeManagerTest {
         assertEquals("The subject should be be the acl: ",
                      "http://localhost:8080/rest/container1/fcr:acl",
                      lastModifiedStatement.getSubject().getURI());
+    }
+
+    @Test
+    public void testUpgradeSkipAcls() throws Exception {
+        //prepare
+        final File tmpDir = tempFolder.newFolder();
+        final File input = new File(TARGET_DIR + "/test-classes/4.7.5-export");
+        final File output = new File(tmpDir, "output");
+        output.mkdir();
+
+        final var config = new Config();
+        config.setSourceVersion(FedoraVersion.V_4_7_5);
+        config.setTargetVersion(FedoraVersion.V_5);
+        config.setInputDir(input);
+        config.setOutputDir(output);
+	config.setSkipAcls(true);
+        //run
+        UpgradeManager upgradeManager = UpgradeManagerFactory.create(config);
+        upgradeManager.start();
+        //ensure all expected files exist
+        final String[] expectedFiles =
+            new String[]{"rest.ttl",
+                         "rest.ttl.headers",
+                         "rest/acl.ttl",
+                         "rest/acl/authZ1.ttl",
+                         "rest/acl/authZ2.ttl",
+                         "rest/external1",
+                         "rest/external1/fcr%3Ametadata.ttl",
+                         "rest/container1.ttl",
+                         "rest/container1.ttl.headers",
+                         "rest/container1/fcr%3Aversions/20201015053947.ttl",
+                         "rest/container1/fcr%3Aversions/20201015053947.ttl.headers",
+                         "rest/container1/fcr%3Aversions/20201015053526.ttl",
+                         "rest/container1/fcr%3Aversions/20201015053526.ttl.headers",
+                         "rest/container1/testbinary.binary",
+                         "rest/container1/testbinary/fcr%3Ametadata.ttl",
+                         "rest/container1/testbinary.binary.headers",
+                         "rest/container1/testbinary/fcr%3Ametadata/fcr%3Aversions/20201015053717.ttl",
+                         "rest/container1/testbinary/fcr%3Ametadata/fcr%3Aversions/20201015053717.ttl.headers",
+                         "rest/container1/testbinary/fcr%3Ametadata/fcr%3Aversions/20201015053848.ttl",
+                         "rest/container1/testbinary/fcr%3Ametadata/fcr%3Aversions/20201015053848.ttl.headers",
+                         "rest/container1/testbinary/fcr%3Aversions/20201015053848.binary",
+                         "rest/container1/testbinary/fcr%3Aversions/20201015053848.binary.headers",
+                         "rest/container1/testbinary/fcr%3Aversions/20201015053717.binary",
+                         "rest/external1.external.headers",
+                         "rest/external1.external"};
+
+        for (String f : expectedFiles) {
+            assertTrue(f + " does not exist as expected", new File(output, f).exists());
+        }
+
+        final String[] unexpectedFiles =
+            new String[]{"rest/container1/fcr%3Aacl.ttl"};
+
+        for (String f : unexpectedFiles) {
+            assertFalse(f + " should not exist.", new File(output, f).exists());
+        }
+
+        //validate acl special handling was skipped
+        //ensure access control statement is still present in the container
+	//acl and authorization resources were migrated and checked in expectedFiles
+        final var model = RdfUtil.parseRdf(Path.of(output.toString(), "rest/container1.ttl"), Lang.TTL);
+        final var accessControlStatement = model.listStatements().toList().stream()
+                                                .filter(x -> x.getPredicate().equals(ACCESS_CONTROL))
+                                                .findFirst().get();
+        assertTrue("There should still be an access control statement", accessControlStatement != null);
     }
 
     private Map<String, List<String>> deserializeHeaders(final File headerFile) throws IOException {


### PR DESCRIPTION
Resolves #55 

# Jira Ticket: https://fedora-repository.atlassian.net/browse/FCREPO-3988

# What does this Pull Request do?
This PR adds an option to skip special handling of Acls and migrates them as normal resources.

# What's new?

* Added `--skip-acls` cli option along with `setIsSkipAcls` and `isSkipAcls` methods in `Config`
* In F47ToF5UpgradeManager:
  * Leave `acl:AccessControl` statements in resources
  * Skip converting Acls into `fcr:acl` resources
  * Skip deletion of `webac:Acl` and `acl:Authorization` resources

# How should this be tested?

Run F4 -> F5 migration with `--skip-acls` option and ensure that `acl:AccessControl` statements remain in original objects and `webac:Acl` and `acl:Authorization` resources were migrated.

# Additional Notes:

This option allows for migrating repositories created with ActiveFedora which used Acls in a way different than Fedora:
* Containers would get `acl:AccessControl` statements linking to Acls
* Acl resources do not have a `webac:Acl` type but do have a `model:hasModel Hydra::AccessControl` statement
* Acl authorization resources do not have an `acl:AccessControl` type but do have a `model:hasModel Hydra::AccessControls::Permission` statement

ActiveFedora should possibly get updated to work with Acls in the way Fedora expects but this options allows for things to keep working in the way ActiveFedora currently expects.

# Interested parties
@whikloj 