### PR TITLE
Clarify which fedora's URI is being specified by --base-uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ usage: java -jar fcrepo-upgrade-util-<version>.jar
                                      acl:Authorization resources normally
  -t,--target-version <arg>           The version of Fedora to which you
                                      are upgrading. Valid values: 5+, 6+
- -u,--base-uri <arg>                 Fedora's base URI. For example,
+ -u,--base-uri <arg>                 Base URI of the source Fedora being
+                                     upgraded. For example,
                                      http://localhost:8080/rest
     --write-to-s3                    Enables writing migrated Fedora 6
                                      data to S3 rather than the local

--- a/src/main/java/org/fcrepo/upgrade/utils/UpgradeUtilDriver.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/UpgradeUtilDriver.java
@@ -255,7 +255,7 @@ public class UpgradeUtilDriver {
         configOptions.addOption(Option.builder("u")
                 .longOpt("base-uri")
                 .hasArg(true)
-                .desc("Fedora's base URI. For example, http://localhost:8080/rest")
+                .desc("Base URI of the source Fedora being upgraded. For example, http://localhost:8080/rest")
                 .required(false)
                 .build());
 


### PR DESCRIPTION
# What does this Pull Request do?
Help text/readme update

# What's new?
Clarify which fedora's URI is being specified by --base-uri in the help text. I initially thought it was the destination base-uri, but this resulted in resources with migrated properties on a different subject uri from the resource itself.

# How should this be tested?
N/A

# Interested parties
@fcrepo/committers
