### PR TITLE
moving to new sonatype maven central URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,9 @@
     repository.
   </description>
   <packaging>jar</packaging>
-
   <repositories>
-    <repository>
       <id>sonatype-nexus-snapshots</id>
-      <url>https://${sonatype.host}/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -35,12 +33,8 @@
     <snapshotRepository>
       <id>sonatype-nexus-snapshots</id>
       <name>Sonatype Nexus Shapshots</name>
-      <url>https://${sonatype.host}/content/repositories/snapshots/</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
-    <repository>
-      <id>sonatype-nexus-staging</id>
-      <url>https://${sonatype.host}/service/local/staging/deploy/maven2/</url>
-    </repository>
   </distributionManagement>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
   </description>
   <packaging>jar</packaging>
   <repositories>
+    <repository>
       <id>sonatype-nexus-snapshots</id>
       <url>https://central.sonatype.com/repository/maven-snapshots/</url>
       <releases>


### PR DESCRIPTION

**JIRA Ticket**: Slack discussion on fcrepo-exts repos not being updated for new sonatype URLs

# What does this Pull Request do?
Changes the URLs to the new con type endpoints for maven deployment to central

# How should this be tested?

* Check GFitHub actions succeed for deploy

Example:
* Does this change require documentation to be updated? 
* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
